### PR TITLE
Dimmers endpoint fix for device level commands

### DIFF
--- a/thingLayer.groovy
+++ b/thingLayer.groovy
@@ -177,9 +177,9 @@ mappings {
 			GET: "updateDimmer"
 		]
 	}
-    path("/switches/:id/:command/:level") {
+    path("/dimmers/:id/:command/:level") {
 		action: [
-			GET: "updateSwitch"
+			GET: "updateDimmer"
 		]
 	}
     path("/motions") {


### PR DESCRIPTION
Looked like the path needed to be fixed for the dimmers endpoint that allows you to pass a level. With this fix the "/dimmers/<device_id>/level/<level>" endpoint should work now for setting the level of an individual dimmer.